### PR TITLE
standard_url_format函数描述和参数配置方法

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -160,7 +160,8 @@ mvn clean package -DskipTests
 | 函数| 描述 |
 |:--|:--|
 |url_encode(value) -> string | escapes value by encoding it so that it can be safely included in URL query parameter names and values|
-|url_decode(value) -> string | unescape the URL encoded value. This function is the inverse of `url_encode`. | 
+|url_decode(value) -> string | unescape the URL encoded value. This function is the inverse of `url_encode`. |
+|standard_url_format(string,string) -> array(varchar) | The normalized url returns the standard url and the 3-level category name|
 
 ### 10. 数学函数
 
@@ -261,6 +262,7 @@ create temporary function regexp_extract_all as 'UDFRe2JRegexpExtractAll';
 create temporary function regexp_like as 'UDFRe2JRegexpLike';
 create temporary function regexp_replace as 'UDFRe2JRegexpReplace';
 create temporary function regexp_split as 'UDFRe2JRegexpSplit';
+create temporary function standard_url_format as 'UDFStandardUrlFormat';
 ```
 
 你可以在hive的命令杭中使用下面的语句来查看函数的细节.
@@ -362,6 +364,7 @@ select gcj_extract_wgs(39.915, 116.404) => {"lng":116.39775549316407,"lat":39.91
 
 ```
 select url_encode('http://shanruifeng.cc/') => http%3A%2F%2Fshanruifeng.cc%2F
+select standard_url_format('wap','https://m.chinagoods.com/en/venue?id=14&dsds=d') => ["https://m.chinagoods.com/en/venue/?id=14","营销会场","营销会场","测试-领券中心"] 
 ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Now, I had already release `hive-third-functions` to maven repositories. To add 
 |:--|:--|
 |url_encode(value) -> string | escapes value by encoding it so that it can be safely included in URL query parameter names and values|
 |url_decode(value) -> string | unescape the URL encoded value. This function is the inverse of `url_encode`. |
+|standard_url_format(string,string) -> array(varchar) | The normalized url returns the standard url and the 3-level category name|
 
 ### 10. math functions
 
@@ -289,6 +290,7 @@ create temporary function regexp_extract_all as 'UDFRe2JRegexpExtractAll';
 create temporary function regexp_like as 'UDFRe2JRegexpLike';
 create temporary function regexp_replace as 'UDFRe2JRegexpReplace';
 create temporary function regexp_split as 'UDFRe2JRegexpSplit';
+create temporary function standard_url_format as 'UDFStandardUrlFormat';
 ```
 
 You can use these statements on hive cli env get detail of function.
@@ -390,6 +392,7 @@ select gcj_extract_wgs(39.915, 116.404) => {"lng":116.39775549316407,"lat":39.91
 
 ```
 select url_encode('http://shanruifeng.cc/') => http%3A%2F%2Fshanruifeng.cc%2F
+select standard_url_format('wap','https://m.chinagoods.com/en/venue?id=14&dsds=d') => ["https://m.chinagoods.com/en/venue/?id=14","营销会场","营销会场","测试-领券中心"] 
 ```
 
 ```

--- a/src/main/java/com/chinagoods/bigdata/functions/url/UDFStandardUrlFormat.java
+++ b/src/main/java/com/chinagoods/bigdata/functions/url/UDFStandardUrlFormat.java
@@ -375,10 +375,10 @@ public class UDFStandardUrlFormat extends GenericUDF {
     public ArrayList<Text> regexDealUrl(String scUrl) throws HiveException {
         String joinKey = scUrl.contains(H5_PREFIX) ? H5 : EMPTY;
         try {
-            String newScUrl = scUrl;
             List<List<String>> platFormRules = allRuleMap.get(platFormType + joinKey);
             if (platFormRules != null) {
                 for (List<String> rules : platFormRules) {
+                    String newScUrl = scUrl;
                     standardUrl = rules.get(2);
                     regex = rules.get(3);
                     unit = rules.get(4);

--- a/src/main/java/com/chinagoods/bigdata/functions/url/UDFStandardUrlFormat.java
+++ b/src/main/java/com/chinagoods/bigdata/functions/url/UDFStandardUrlFormat.java
@@ -1,0 +1,504 @@
+package com.chinagoods.bigdata.functions.url;
+
+import com.chinagoods.bigdata.functions.utils.MysqlUtil;
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorConverters;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author zyl
+ * date: 2022-09-24
+ * time: 16:30
+ */
+@Description(name = "standard_url_format"
+        , value = "_FUNC_(string,string) - Normalize the url according to the rule, returning an array of processed urls and a tertiary directory name if present, or an array of default values if absent"
+        , extended = "Example:\n> SELECT _FUNC_(platform_type,sc_url) FROM src;")
+public class UDFStandardUrlFormat extends GenericUDF {
+    private static final Logger logger = LoggerFactory.getLogger(UDFStandardUrlFormat.class);
+    private static final String DB_URL = "jdbc:mysql://rm-uf6wr9aa537v0tesf3o.mysql.rds.aliyuncs.com:3306/source?characterEncoding=UTF-8&useSSL=false";
+    private static final String DB_USER = "datax";
+    private static final String DB_PASSWORD = "oRvmRrVJeOCl8XsY";
+    /**
+     * 菜单映射信息,该表是mysql触发器逻辑生成的数据，触发器名称 standard_url_param_maping_trigger
+     */
+    private static final String MENU_MAPING_SQL = "select key_desc,value_desc from standard_url_param_maping";
+    /**
+     * 特殊URL
+     */
+    private static final String STANDARD_SPECIAL_URL_SQL = "select url,fixed_identity,fixed_param,mapping_key,unit,sub_unit,url_param_keys,param_type,page_link_name from standard_special_url where url_type=%s";
+    /**
+     * 标准url匹配规则信息
+     */
+    private static final String RULE_SQL = "select platform_type,case when standard_url like '%://h%' then 'Y' else 'N' end is_h5,standard_url, regex, unit,sub_unit,page_name,params from standard_rule_url " +
+            "where lang = 'zh' and unit is not null and sub_unit is not null and page_name is not null and platform_type is not null and sc_url!='' and regex is not null and regex!=''";
+    /**
+     * 静态URL信息
+     */
+    private static final String STATIC_URL_SQL = "select standard_url, concat(unit,'---',sub_unit,'---',page_name) url_name from standard_rule_url where lang = 'zh' and (regex is null or regex = '') and standard_url is not null";
+    /**
+     * 特殊URL信息
+     **/
+    private List<List<String>> menuUrlList = new ArrayList<>();
+    private List<List<String>> specialUrlList = new ArrayList<>();
+    /**
+     * 参数k-v映射信息
+     **/
+    private Map<String, String> paramKvMap = new HashMap<>();
+    /**
+     * 标准化URL规则
+     **/
+    private List<List<String>> standardUrlList = new ArrayList<>();
+    /**
+     * 汇总规则
+     */
+    private Map<String, List<List<String>>> allRuleMap = new HashMap<String, List<List<String>>>();
+    private Map<String, String> staticUrlMap = new HashMap<String, String>();
+    private ObjectInspectorConverters.Converter[] converters;
+    private static final int ARG_COUNT = 2;
+    private static final String HTTP_PREFIX = "http:";
+    private static final String HTTPS_PREFIX = "https:";
+    private static final String H5_PREFIX = "://h";
+    private static final String FLAG = "Y";
+    private static final String ONE = "1";
+    private static final String TWO = "2";
+    private static final String EMPTY = "";
+    //约定空字符用NULL替换
+    private static final String PARAM_NULL = "NULL";
+    private static final String SEPARATOR = "---";
+    private static final String KV_SEPARATOR = "--";
+    private static final String CONNECTOR_SEPARATOR = "?";
+    private static final String REGEX_OR_PARAM_SEPARATOR = "/&/";
+    private static final String BACKSLASH = "/";
+    private static final String PARAM_SEPARATOR = "&";
+    private static final String EQ = "=";
+    private static final String COMMA = ",";
+
+    /**
+     * 固定参数
+     */
+    private static final String T = "T--";
+    private static final String Z = "Z--";
+    private static final String M = "M--";
+    private static final String S = "S--";
+    private static final String C = "C--";
+    private static final String IMT = "IMT--0";
+    private static final String STANDARD_ZERO = "0000";
+    private static final String H5 = "h5";
+    private static final String FIXED_PARAM = "fixed_param";
+    /**
+     * 返回结果list元素
+     */
+    private String platFormType = null;
+    private String standardUrl = null;
+    private String unit = null;
+    private String subUnit = null;
+    private String pageName = null;
+    private String regex = null;
+    private String params = null;
+    private ArrayList<Text> resultPageNameList = null;
+
+    public UDFStandardUrlFormat() {
+    }
+
+    @Override
+    public ObjectInspector initialize(ObjectInspector[] arguments) throws UDFArgumentException {
+        if (arguments.length != ARG_COUNT) {
+            throw new UDFArgumentException(
+                    "The function standard_url_format takes exactly " + ARG_COUNT + " arguments.");
+        }
+        converters = new ObjectInspectorConverters.Converter[arguments.length];
+        for (int i = 0; i < arguments.length; i++) {
+            converters[i] = ObjectInspectorConverters.getConverter(arguments[i],
+                    PrimitiveObjectInspectorFactory.javaStringObjectInspector);
+        }
+//        Long start0 = System.currentTimeMillis();
+        initRules();
+//        Long end0 = System.currentTimeMillis();
+//        logger.info("init times {} ms", (end0 - start0));
+        return ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector);
+    }
+
+    @Override
+    public ArrayList<Text> evaluate(DeferredObject[] arguments) throws HiveException {
+        assert (arguments.length == ARG_COUNT);
+        initParam();
+        String scUrl = null;
+        if (arguments == null || arguments.length < 2) {
+            return resultPageNameList;
+        } else {
+            platFormType = converters[0].convert(arguments[0].get()).toString();
+            scUrl = converters[0].convert(arguments[1].get()).toString();
+            if (StringUtils.isBlank(scUrl) || StringUtils.isBlank(platFormType)) {
+                return resultPageNameList;
+            }
+            //标准化url
+            if (scUrl.contains(HTTP_PREFIX)) {
+                scUrl = scUrl.replace(HTTP_PREFIX, HTTPS_PREFIX);
+            }
+            if (scUrl.contains(HTTPS_PREFIX)) {
+                if (scUrl.contains(CONNECTOR_SEPARATOR) && !scUrl.contains(EQ + HTTP_PREFIX) && !scUrl.contains(EQ + HTTPS_PREFIX)) {
+                    String requestUrl = scUrl.substring(0, scUrl.indexOf(CONNECTOR_SEPARATOR));
+                    String requestUrlParam = scUrl.substring(scUrl.indexOf(CONNECTOR_SEPARATOR), scUrl.length());
+                    scUrl = requestUrl.lastIndexOf(BACKSLASH) + 1 == requestUrl.length() ? scUrl : requestUrl + BACKSLASH + requestUrlParam;
+                } else if (scUrl.contains(CONNECTOR_SEPARATOR) && (scUrl.contains(EQ + HTTP_PREFIX) || scUrl.contains(EQ + HTTPS_PREFIX))) {
+                    scUrl = scUrl + BACKSLASH;
+                } else {
+                    scUrl = scUrl.lastIndexOf(BACKSLASH) + 1 == scUrl.length() ? scUrl : scUrl + BACKSLASH;
+                }
+            }
+        }
+//        Long start1 = System.currentTimeMillis();
+        meunDealUrl(scUrl);
+//        Long end1 = System.currentTimeMillis();
+//        logger.info("Dynamically generating menu urls takes time {} ms", end1 - start1);
+
+//        Long start2 = System.currentTimeMillis();
+        resultPageNameList = specialParamDealUrl(scUrl);
+//        Long end2 = System.currentTimeMillis();
+//        logger.info("It takes time to match the special URL list {} ms", end2 - start2);
+
+//        Long start3 = System.currentTimeMillis();
+        if (resultPageNameList.get(0).toString().equals(STANDARD_ZERO)) {
+            resultPageNameList = regexDealUrl(scUrl);
+        }
+//        Long end3 = System.currentTimeMillis();
+//        logger.info("Matching the official rule list takes time {} ms", end3 - start3);
+        return resultPageNameList;
+    }
+
+    /**
+     * 初始化规则信息
+     *
+     * @throws UDFArgumentException
+     */
+    public void initRules() throws UDFArgumentException {
+        // 配置信息
+        MysqlUtil mysqlUtil = new MysqlUtil(DB_URL, DB_USER, DB_PASSWORD);
+        try {
+            paramKvMap = mysqlUtil.getMap(MENU_MAPING_SQL);
+            menuUrlList = mysqlUtil.getLists(String.format(STANDARD_SPECIAL_URL_SQL, ONE));
+            mysqlUtil.getLists(RULE_SQL).stream().forEach(rules -> {
+                platFormType = rules.get(0);
+                String h5Key = rules.get(1).equals(FLAG) ? H5 : EMPTY;
+                if (allRuleMap.get(platFormType + h5Key) == null) {
+                    standardUrlList = new ArrayList<>();
+                    standardUrlList.add(rules);
+                    allRuleMap.put(platFormType + h5Key, standardUrlList);
+                } else {
+                    allRuleMap.get(platFormType + h5Key).add(rules);
+                    allRuleMap.put(platFormType + h5Key, allRuleMap.get(platFormType + h5Key));
+                }
+            });
+            staticUrlMap = mysqlUtil.getMap(STATIC_URL_SQL);
+            //特殊url动态生成
+            specialUrlList = mysqlUtil.getLists(String.format(STANDARD_SPECIAL_URL_SQL, TWO));
+            specialUrlList.forEach(urlList -> {
+                //固定参数
+                String fixedParam = urlList.get(2);
+                //参数对应的枚举key前缀
+                String mappingKey = urlList.get(3);
+                unit = urlList.get(4);
+                subUnit = urlList.get(5);
+                String paramType = urlList.get(7);
+                paramKvMap.forEach((key, value) -> {
+                    String url = urlList.get(0);
+                    String paramKeyPrex = key.split(KV_SEPARATOR)[0];
+                    String paramValue = key.split(KV_SEPARATOR)[1];
+                    if (paramType.equals(ONE)) {
+                        if (mappingKey.equals(paramKeyPrex) && !fixedParam.contains(FIXED_PARAM)) {
+                            url = url.replace(fixedParam, fixedParam.replace(STANDARD_ZERO, paramValue));
+                        }
+                        if (mappingKey.equals(paramKeyPrex) && fixedParam.contains(FIXED_PARAM)) {
+                            url = url.replace(fixedParam, fixedParam.replace(fixedParam, paramValue));
+                        }
+                        if (!url.contains(STANDARD_ZERO) && !url.contains(FIXED_PARAM)) {
+                            staticUrlMap.put(url, String.join(SEPARATOR, unit, subUnit, value));
+                        }
+                    } else if (paramType.equals(TWO)) {
+                        staticUrlMap.put(paramValue, value);
+                    }
+                });
+            });
+            //统一转小写
+            toLowerMap(staticUrlMap);
+            toLowerMap(paramKvMap);
+        } catch (Exception e) {
+            logger.error("Failed to query the standard rule. Procedure, the error details are: ", e);
+            throw new UDFArgumentException(String.format("Failed to query the standard rule. Procedure, the error details are: %s", e));
+        }
+    }
+
+    /**
+     * 处理菜单URL
+     *
+     * @param scUrl
+     * @return
+     */
+    public ArrayList<Text> meunDealUrl(String scUrl) throws HiveException {
+        try {
+            //菜单固定参数
+            if (StringUtils.contains(scUrl, Z) || StringUtils.contains(scUrl, T) || StringUtils.contains(scUrl, M) || StringUtils.contains(scUrl, S) || StringUtils.contains(scUrl, C)) {
+                //遍历菜单URL
+                for (List<String> ls : menuUrlList) {
+                    //当URL时菜单路径
+                    if (StringUtils.contains(scUrl, ls.get(0))) {
+                        unit = ls.get(4);
+                        subUnit = ls.get(5);
+                        String pageLinkName = ls.get(8);
+                        //当URL包含多个key
+                        int indexStart = scUrl.lastIndexOf(ls.get(0)) + ls.get(0).length();
+                        int indexEnd = scUrl.lastIndexOf(BACKSLASH);
+                        String paramUrl = scUrl.substring(indexStart, indexEnd).toLowerCase();
+                        if (paramUrl.contains(SEPARATOR)) {
+                            List<String> nameList = new ArrayList<>();
+                            //search搜索存在搜索后赛选的情况，给固定格式
+                            if (paramUrl.contains(BACKSLASH)) {
+                                nameList.add(paramUrl.substring(0, paramUrl.indexOf(BACKSLASH) - 1));
+                                paramUrl = paramUrl.substring(paramUrl.indexOf(BACKSLASH) + 1, paramUrl.length());
+                            }
+                            String[] keysArr = paramUrl.split(SEPARATOR);
+                            for (String key : keysArr) {
+                                if (!key.equals(IMT.toLowerCase())) {
+                                    nameList.add(paramKvMap.get(key));
+                                }
+                            }
+                            pageName = String.join(SEPARATOR, nameList);
+                        } else {
+                            pageName = paramKvMap.get(paramUrl);
+                        }
+                        setListValue(scUrl, unit, subUnit, pageName, pageLinkName);
+                        break;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Menu URL handling error,url is {},error is ", scUrl, e);
+            throw new HiveException("Menu URL handling error,url is " + scUrl + ",error is ", e);
+        }
+        return resultPageNameList;
+    }
+
+    /**
+     * 处理特殊固定参数的URL和无正则url处理
+     *
+     * @param scUrl
+     * @return
+     */
+    public ArrayList<Text> specialParamDealUrl(String scUrl) throws HiveException {
+        try {
+            //区分是否特殊URL
+            boolean isSpecial = false;
+            for (List<String> rowList : specialUrlList) {
+                if (scUrl.contains(rowList.get(1))) {
+                    isSpecial = true;
+                }
+            }
+            //无正则url处理
+            if (!isSpecial && scUrl.contains(CONNECTOR_SEPARATOR)) {
+                getStaticUrl(scUrl.substring(0, scUrl.indexOf(CONNECTOR_SEPARATOR)), null);
+                return resultPageNameList;
+            } else if (!isSpecial || !scUrl.contains(CONNECTOR_SEPARATOR)) {
+                getStaticUrl(scUrl, null);
+                return resultPageNameList;
+            }
+            //特殊url处理
+            if (isSpecial) {
+                for (List<String> urlList : specialUrlList) {
+                    String url = urlList.get(0);
+                    String fixedIdentity = urlList.get(1);
+                    String paramType = urlList.get(7);
+                    String pageLinkName = urlList.get(8);
+                    URL urls = new URL(scUrl);
+                    String host = urls.getHost();
+                    if (scUrl.contains(fixedIdentity) && url.contains(host)) {
+                        if (paramType.equals(ONE)) {
+                            String urlParamKeys = urlList.get(6);
+                            if (StringUtils.isNotBlank(urlParamKeys)) {
+                                String[] urlParamKeysArray = urlParamKeys.split(COMMA);
+                                Map<String, List<String>> map = getUrlparameter(scUrl, urlParamKeysArray);
+                                map.forEach((k, v) -> {
+                                    standardUrl = String.join(CONNECTOR_SEPARATOR, k, String.join(PARAM_SEPARATOR, v));
+                                });
+                            }
+                        } else if (paramType.equals(TWO)) {
+                            if (!url.contains(CONNECTOR_SEPARATOR)) {
+                                standardUrl = scUrl.substring(0, scUrl.indexOf(CONNECTOR_SEPARATOR));
+                            }
+                        }
+                        if (StringUtils.isBlank(standardUrl)) {
+                            standardUrl = scUrl;
+                        }
+                        if (StringUtils.isNotBlank(standardUrl)) {
+                            //静态url获取三级名称
+                            getStaticUrl(standardUrl, pageLinkName);
+                            return resultPageNameList;
+                        }
+                    }
+                }
+
+            }
+
+        } catch (Exception e) {
+            logger.error("Error handling special parameter URL,url is {},error is ", scUrl, e);
+            throw new HiveException("Error handling special parameter URL ,url is " + scUrl + ",error is ", e);
+        }
+        return resultPageNameList;
+    }
+
+    /**
+     * 处理正则匹配的URL
+     *
+     * @param scUrl
+     * @return
+     */
+    public ArrayList<Text> regexDealUrl(String scUrl) throws HiveException {
+        String joinKey = scUrl.contains(H5_PREFIX) ? H5 : EMPTY;
+        try {
+            String newScUrl = scUrl;
+            List<List<String>> platFormRules = allRuleMap.get(platFormType + joinKey);
+            if (platFormRules != null) {
+                for (List<String> rules : platFormRules) {
+                    standardUrl = rules.get(2);
+                    regex = rules.get(3);
+                    unit = rules.get(4);
+                    subUnit = rules.get(5);
+                    pageName = rules.get(6);
+                    params = rules.get(7);
+                    //多正则匹配
+                    if (StringUtils.isNotBlank(regex)) {
+                        String[] regexArray = regex.split(REGEX_OR_PARAM_SEPARATOR);
+                        String[] ruleParamsArray = params.split(REGEX_OR_PARAM_SEPARATOR);
+                        for (int i = 0; i < regexArray.length; i++) {
+                            newScUrl = newScUrl.replaceAll(regexArray[i], ruleParamsArray[i].replace(PARAM_NULL, ""));
+                        }
+                    } else {
+                        newScUrl = scUrl.replaceAll(regex, STANDARD_ZERO);
+                    }
+                    newScUrl = newScUrl.lastIndexOf(BACKSLASH) + 1 == newScUrl.length() ? newScUrl : newScUrl + BACKSLASH;
+                    if (newScUrl.equals(standardUrl)) {
+                        setListValue(standardUrl, unit, subUnit, pageName, null);
+                        return resultPageNameList;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Regular expression rule URL processing error,url is {},error is ", scUrl, e);
+            throw new HiveException("Regular expression rule URL processing error ,url is " + scUrl + ",error is ", e);
+        }
+        return resultPageNameList;
+    }
+
+    /**
+     * 从静态url中获取pagename
+     *
+     * @param standardUrl
+     */
+    public void getStaticUrl(String standardUrl, String pageLinkName) {
+        String pageSeparatorName = staticUrlMap.get(standardUrl.toLowerCase());
+        if (!StringUtils.isBlank(pageSeparatorName)) {
+            String[] pageNameArr = pageSeparatorName.split(SEPARATOR);
+            setListValue(standardUrl, pageNameArr[0], pageNameArr[1], pageNameArr[2], pageLinkName);
+        }
+    }
+
+    /**
+     * 初始化变量
+     */
+    public void initParam() {
+        platFormType = null;
+        standardUrl = null;
+        unit = null;
+        subUnit = null;
+        pageName = null;
+        regex = null;
+        params = null;
+        resultPageNameList = new ArrayList<>(4);
+        resultPageNameList.add(new Text("0000"));
+        resultPageNameList.add(new Text("0000"));
+        resultPageNameList.add(new Text("0000"));
+        resultPageNameList.add(new Text("0000"));
+    }
+
+    /**
+     * 返回结果赋值
+     *
+     * @param standardUrl
+     * @param unit
+     * @param subUnit
+     * @param pageName
+     * @return
+     */
+    public void setListValue(String standardUrl, String unit, String subUnit, String pageName, String pageLinkName) {
+        if (StringUtils.isNotBlank(standardUrl) && StringUtils.isNotBlank(unit) && StringUtils.isNotBlank(subUnit)
+                && StringUtils.isNotBlank(pageName)) {
+            resultPageNameList.set(0, new Text(standardUrl));
+            resultPageNameList.set(1, new Text(unit));
+            resultPageNameList.set(2, new Text(subUnit));
+            resultPageNameList.set(3, new Text(pageName + (pageLinkName == null ? "" : pageLinkName)));
+        }
+    }
+
+    /**
+     * url转小写获取
+     *
+     * @param map
+     * @return
+     */
+    public void toLowerMap(Map<String, String> map) {
+        Map<String, String> lowerMap = new HashMap<String, String>();
+        map.forEach((key, value) -> {
+            lowerMap.put(key.toLowerCase(), value);
+        });
+        map.clear();
+        map.putAll(lowerMap);
+    }
+
+    /**
+     * 提取URL指定参数和请求域名
+     *
+     * @param url
+     * @param keyArr
+     * @return
+     */
+    public static Map<String, List<String>> getUrlparameter(String url, String[] keyArr) {
+        List<String> list = new ArrayList<>();
+        Map<String, List<String>> map = new HashMap<String, List<String>>();
+        String domainUrl = null;
+        if (StringUtils.isNotBlank(url) && keyArr.length > 0) {
+            domainUrl = url.substring(0, url.indexOf(CONNECTOR_SEPARATOR));
+            for (int i = 0; i < keyArr.length; i++) {
+                Pattern pattern = Pattern.compile(keyArr[i] + "=([^&]*)");
+                Matcher matcher = pattern.matcher(url);
+                if (matcher.find()) {
+                    String value = matcher.group(0).split("=")[1].replace(PARAM_SEPARATOR, EMPTY) == null ? null : matcher.group(0).split("=")[1].replace(PARAM_SEPARATOR, EMPTY);
+                    list.add(keyArr[i] + EQ + value);
+                }
+            }
+        }
+        map.put(domainUrl, list);
+        return map;
+    }
+
+    @Override
+    public String getDisplayString(String[] strings) {
+        assert (strings.length == ARG_COUNT);
+        return "standard_url_format(" + strings[0] + ", " + strings[1] + ")";
+    }
+}

--- a/src/main/java/com/chinagoods/bigdata/functions/url/UDFStandardUrlFormat.java
+++ b/src/main/java/com/chinagoods/bigdata/functions/url/UDFStandardUrlFormat.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
  * time: 16:30
  * describe: 此函数从基础规则表standard_rule_url，特殊url规则表standard_special_url查询相关规则进行匹配
  * 上述规则数据基于k-v映射表standard_url_param_maping动态生成固定url相关数据，参考见数据库触发器standard_url_param_maping_trigger（依赖于market_industry，sys_map，category，venue，active_meeting，cms_category，cms_article表数据）
- * standard_rule_url配置：1.无参url（包含参数在url中，不在问号后的）不用配置正则 2.有参url按照正则替换，正则可多个，用/&/分割，params参数也用/&/分割，空使用NULL字符串代替，其他使用0000代替 3.正则中\\使用\
+ * standard_rule_url配置：1.无参url（包含参数在url中，不在问号后的）不用配置正则 2.有参url按照正则替换，正则可多个，用/&/分割，params参数也用/&/分割，空使用NULL字符串代替，其他使用0000代替 3.正则中\\使用\ 4.规则配置时，如果原始url符合特殊url表standard_special_url中规则，则正则表达式字段不能为空，否则处理不了
  * standard_special_url配置：1、url,unit,sub_unit必填 2.前置条件param_type为1代表参数替换；fixed_identity代表url包含这个字符串就是按照次规则匹配 3.fixed_param字段参数包含0000，用mapping_key的key中---后的部分替换0000部分；值为fixed_param字符串的，则使用mapping_key的key中---后的部分直接替换fixed_param，如果url_param_keys有值，则按照顺序拼接作为参数直接替换fixed_param（如code=112&active_code=112&id=3）3.前置条件param_type为2代表参数替换；用mapping_key的key中---后的部分替换fixed_param；4.mapping_key的标识必须和standard_url_param_maping中的key_desc的前缀保持一致
  */
 @Description(name = "standard_url_format"

--- a/src/main/java/com/chinagoods/bigdata/functions/url/UDFStandardUrlFormat.java
+++ b/src/main/java/com/chinagoods/bigdata/functions/url/UDFStandardUrlFormat.java
@@ -26,6 +26,10 @@ import java.util.regex.Pattern;
  * @author zyl
  * date: 2022-09-24
  * time: 16:30
+ * describe: 此函数从基础规则表standard_rule_url，特殊url规则表standard_special_url查询相关规则进行匹配
+ * 上述规则数据基于k-v映射表standard_url_param_maping动态生成固定url相关数据，参考见数据库触发器standard_url_param_maping_trigger（依赖于market_industry，sys_map，category，venue，active_meeting，cms_category，cms_article表数据）
+ * standard_rule_url配置：1.无参url（包含参数在url中，不在问号后的）不用配置正则 2.有参url按照正则替换，正则可多个，用/&/分割，params参数也用/&/分割，空使用NULL字符串代替，其他使用0000代替 3.正则中\\使用\
+ * standard_special_url配置：1、url,unit,sub_unit必填 2.前置条件param_type为1代表参数替换；fixed_identity代表url包含这个字符串就是按照次规则匹配 3.fixed_param字段参数包含0000，用mapping_key的key中---后的部分替换0000部分；值为fixed_param字符串的，则使用mapping_key的key中---后的部分直接替换fixed_param，如果url_param_keys有值，则按照顺序拼接作为参数直接替换fixed_param（如code=112&active_code=112&id=3）3.前置条件param_type为2代表参数替换；用mapping_key的key中---后的部分替换fixed_param；4.mapping_key的标识必须和standard_url_param_maping中的key_desc的前缀保持一致
  */
 @Description(name = "standard_url_format"
         , value = "_FUNC_(string,string) - Normalize the url according to the rule, returning an array of processed urls and a tertiary directory name if present, or an array of default values if absent"

--- a/src/main/java/com/chinagoods/bigdata/functions/utils/MysqlUtil.java
+++ b/src/main/java/com/chinagoods/bigdata/functions/utils/MysqlUtil.java
@@ -66,7 +66,7 @@ final public class MysqlUtil {
     }
 
     public Set<String> getSet(String sql) throws SQLException {
-        Set<String> set = new HashSet<>(3000);
+        Set<String> set = new HashSet<>();
         // 重建mysql连接信息
         if (connection == null || connection.isClosed()) {
             connection = getConnection();
@@ -108,7 +108,7 @@ final public class MysqlUtil {
     }
 
     public Map<String,String> getMap(String sql) throws SQLException {
-        Map<String,String> map = new HashMap<>(5000);
+        Map<String,String> map = new HashMap<>();
         // 重建mysql连接信息
         if (connection == null || connection.isClosed()) {
             connection = getConnection();

--- a/src/main/java/com/chinagoods/bigdata/functions/utils/MysqlUtil.java
+++ b/src/main/java/com/chinagoods/bigdata/functions/utils/MysqlUtil.java
@@ -4,8 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.*;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 /**
  * @author xiaowei.song
@@ -64,6 +63,66 @@ final public class MysqlUtil {
         rs.close();
         stmt.close();
         return keywordsSet;
+    }
+
+    public Set<String> getSet(String sql) throws SQLException {
+        Set<String> set = new HashSet<>(3000);
+        // 重建mysql连接信息
+        if (connection == null || connection.isClosed()) {
+            connection = getConnection();
+        }
+        Statement stmt = connection.createStatement();
+        ResultSet rs = stmt.executeQuery(sql);
+        // 展开结果集数据库
+        while(rs.next()) {
+            for (int i = 0; i < rs.getMetaData().getColumnCount(); i++) {
+                set.add((String) rs.getObject(i + 1));
+            }
+        }
+        // 完成后关闭
+        rs.close();
+        stmt.close();
+        return set;
+    }
+    
+    public List<List<String>> getLists(String sql) throws SQLException {
+        List<List<String>> resultlist = new ArrayList<>();
+        // 重建mysql连接信息
+        if (connection == null || connection.isClosed()) {
+            connection = getConnection();
+        }
+        Statement stmt = connection.createStatement();
+        ResultSet rs = stmt.executeQuery(sql);
+        // 展开结果集数据库
+        while(rs.next()) {
+            List<String> list = new ArrayList<>();
+            for (int i = 0; i < rs.getMetaData().getColumnCount(); i++) {
+                list.add((String) rs.getObject(i + 1));
+            }
+            resultlist.add(list);
+        }
+        // 完成后关闭
+        rs.close();
+        stmt.close();
+        return resultlist;
+    }
+
+    public Map<String,String> getMap(String sql) throws SQLException {
+        Map<String,String> map = new HashMap<>(5000);
+        // 重建mysql连接信息
+        if (connection == null || connection.isClosed()) {
+            connection = getConnection();
+        }
+        Statement stmt = connection.createStatement();
+        ResultSet rs = stmt.executeQuery(sql);
+        // 展开结果集数据库
+        while(rs.next()) {
+            map.put((String) rs.getObject(1),(String) rs.getObject(2));
+        }
+        // 完成后关闭
+        rs.close();
+        stmt.close();
+        return map;
     }
 
     public void close() throws SQLException {

--- a/src/test/java/com/chinagoods/bigdata/functions/url/UDFStandardUrlFormatTest.java
+++ b/src/test/java/com/chinagoods/bigdata/functions/url/UDFStandardUrlFormatTest.java
@@ -33,39 +33,40 @@ public class UDFStandardUrlFormatTest {
 
         ArrayList<Text> reslist = null;
         GenericUDF.DeferredObject sourceObj = new GenericUDF.DeferredJavaObject("pc");
-        GenericUDF.DeferredObject patternObj = new GenericUDF.DeferredJavaObject("https://h5en.chinagoods.com/searchMap/index/?mark=01");
+        GenericUDF.DeferredObject patternObj = new GenericUDF.DeferredJavaObject("https://news.chinagoods.com/information/11/search/减免租金");
         GenericUDF.DeferredObject[] args = {sourceObj, patternObj};
         reslist = udf.evaluate(args);
         System.out.println(reslist);
 
-      /*  String RULE_SQL = "select platform_type,sc_url from test2 where" +
-                 " sc_url not like 'http://localhost%' " +
-                "and sc_url not like 'https://localhost%' " +
-                "and sc_url not like 'http://%.%.%.%' " +
-                "and sc_url not like 'https://%.%.%.%' " +
-                "and sc_url not like '%cgb.chinagoods.com%'";
-        MysqlUtil mysqlUtil = new MysqlUtil(DB_URL, DB_USER, DB_PASSWORD);
-        List<List<String>> list = mysqlUtil.getLists(RULE_SQL);
-        int a = 0;
-        for (List<String> r:list) {
-            ArrayList<Text> reslist1 = new ArrayList<>();
-            List<String> array = null;
-            try {
-                GenericUDF.DeferredObject sourceObj1 = new GenericUDF.DeferredJavaObject("wap");
-                GenericUDF.DeferredObject patternObj1 = new GenericUDF.DeferredJavaObject("https://m.chinagoods.com/en/venue?id=14&dsds=d");
-                GenericUDF.DeferredObject[] args1 = {sourceObj1, patternObj1};
-                reslist1 = udf.evaluate(args1);
-            } catch (Exception e) {
-                e.printStackTrace();
-                System.out.println(array);
-            }
-            if (reslist1.size() != 4 || (reslist1.get(0).equals("0000") && reslist1.get(1).equals("0000")
-            && reslist1.get(2).equals("0000") && reslist1.get(3).equals("0000"))) {
-                a++;
-                System.out.println(a+"************************");
-                System.out.println(r.get(0) + "-----" + r.get(1) + "-----" + reslist1);
-            }
-        }*/
+//        String RULE_SQL = "select platform_type,sc_url from test2 where" +
+//                 " sc_url not like 'http://localhost%' " +
+//                "and sc_url not like 'https://localhost%' " +
+//                "and sc_url not like 'http://%.%.%.%' " +
+//                "and sc_url not like 'https://%.%.%.%' " +
+//                "and sc_url not like '%cgb.chinagoods.com%'";
+
+//        String RULE_SQL = "select platform_type,sc_url from standard_rule_url where regex is not null";
+//        MysqlUtil mysqlUtil = new MysqlUtil(DB_URL, DB_USER, DB_PASSWORD);
+//        List<List<String>> list = mysqlUtil.getLists(RULE_SQL);
+//        int a = 0;
+//        for (List<String> r:list) {
+//            ArrayList<Text> reslist1 = new ArrayList<>();
+//            List<String> array = null;
+//            try {
+//                GenericUDF.DeferredObject sourceObj1 = new GenericUDF.DeferredJavaObject(r.get(0));
+//                GenericUDF.DeferredObject patternObj1 = new GenericUDF.DeferredJavaObject(r.get(1));
+//                GenericUDF.DeferredObject[] args1 = {sourceObj1, patternObj1};
+//                reslist1 = udf.evaluate(args1);
+//            } catch (Exception e) {
+//                e.printStackTrace();
+//                System.out.println(array);
+//            }
+//            if (reslist1.size() != 4 || reslist1.get(0).toString().equals("0000")) {
+//                a++;
+//                System.out.println(a+"************************");
+//                System.out.println(r.get(0) + "-----" + r.get(1) + "-----" + reslist1);
+//            }
+//        }
 
     }
 }

--- a/src/test/java/com/chinagoods/bigdata/functions/url/UDFStandardUrlFormatTest.java
+++ b/src/test/java/com/chinagoods/bigdata/functions/url/UDFStandardUrlFormatTest.java
@@ -1,0 +1,71 @@
+package com.chinagoods.bigdata.functions.url;
+
+import com.chinagoods.bigdata.functions.utils.MysqlUtil;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.io.Text;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class UDFStandardUrlFormatTest {
+    private static final Logger logger = LoggerFactory.getLogger(UDFStandardUrlFormat.class);
+    private static final String DB_URL = "jdbc:mysql://rm-uf6wr9aa537v0tesf3o.mysql.rds.aliyuncs.com:3306/source?characterEncoding=UTF-8&useSSL=false";
+    private static final String DB_USER = "datax";
+    private static final String DB_PASSWORD = "oRvmRrVJeOCl8XsY";
+
+
+    @Test
+    public void testUrlEncode() throws Exception {
+        UDFStandardUrlFormat udf = new UDFStandardUrlFormat();
+        ObjectInspector platform_type = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+        ObjectInspector sc_url = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+        ObjectInspector[] arguments = {platform_type, sc_url};
+        udf.initialize(arguments);
+
+        ArrayList<Text> reslist = null;
+        GenericUDF.DeferredObject sourceObj = new GenericUDF.DeferredJavaObject("pc");
+        GenericUDF.DeferredObject patternObj = new GenericUDF.DeferredJavaObject("https://h5en.chinagoods.com/searchMap/index/?mark=01");
+        GenericUDF.DeferredObject[] args = {sourceObj, patternObj};
+        reslist = udf.evaluate(args);
+        System.out.println(reslist);
+
+      /*  String RULE_SQL = "select platform_type,sc_url from test2 where" +
+                 " sc_url not like 'http://localhost%' " +
+                "and sc_url not like 'https://localhost%' " +
+                "and sc_url not like 'http://%.%.%.%' " +
+                "and sc_url not like 'https://%.%.%.%' " +
+                "and sc_url not like '%cgb.chinagoods.com%'";
+        MysqlUtil mysqlUtil = new MysqlUtil(DB_URL, DB_USER, DB_PASSWORD);
+        List<List<String>> list = mysqlUtil.getLists(RULE_SQL);
+        int a = 0;
+        for (List<String> r:list) {
+            ArrayList<Text> reslist1 = new ArrayList<>();
+            List<String> array = null;
+            try {
+                GenericUDF.DeferredObject sourceObj1 = new GenericUDF.DeferredJavaObject("wap");
+                GenericUDF.DeferredObject patternObj1 = new GenericUDF.DeferredJavaObject("https://m.chinagoods.com/en/venue?id=14&dsds=d");
+                GenericUDF.DeferredObject[] args1 = {sourceObj1, patternObj1};
+                reslist1 = udf.evaluate(args1);
+            } catch (Exception e) {
+                e.printStackTrace();
+                System.out.println(array);
+            }
+            if (reslist1.size() != 4 || (reslist1.get(0).equals("0000") && reslist1.get(1).equals("0000")
+            && reslist1.get(2).equals("0000") && reslist1.get(3).equals("0000"))) {
+                a++;
+                System.out.println(a+"************************");
+                System.out.println(r.get(0) + "-----" + r.get(1) + "-----" + reslist1);
+            }
+        }*/
+
+    }
+}


### PR DESCRIPTION
此函数从基础规则表standard_rule_url，特殊url规则表standard_special_url查询相关规则进行匹配
上述规则数据基于k-v映射表standard_url_param_maping动态生成固定url相关数据，参考见数据库触发器standard_url_param_maping_trigger（依赖于market_industry，sys_map，category，venue，active_meeting，cms_category，cms_article表数据）

standard_rule_url配置：1.无参url（包含参数在url中，不在问号后的）不用配置正则 2.有参url按照正则替换，正则可多个，用/&/分割，params参数也用/&/分割，空使用‘NULL’字符串代替，其他使用0000代替 3.正则中\\使用\ 

standard_special_url配置：
1、url,unit,sub_unit必填
 2.前置条件param_type为1代表参数替换；fixed_identity代表url包含这个字符串就是按照次规则匹配
 3.fixed_param字段参数包含0000，用mapping_key的key中---后的部分替换0000部分；值为fixed_param字符串的，则使用mapping_key的key中---后的部分直接替换fixed_param，如果url_param_keys有值，则按照顺序拼接作为参数直接替换fixed_param（如code=112&active_code=112&id=3）
4.前置条件param_type为2代表参数替换；用mapping_key的key中---后的部分替换fixed_param；
5.mapping_key的标识必须和standard_url_param_maping中的key_desc的前缀保持一致